### PR TITLE
ignoredFiles is an empty array by default

### DIFF
--- a/tasks/nodemon.js
+++ b/tasks/nodemon.js
@@ -12,8 +12,12 @@ module.exports = function (grunt) {
   grunt.registerMultiTask('nodemon', 'Starts a nodemon server.', function () {
 
     var command = [];
-    var options = this.options();
     var done = this.async();
+    var options = {
+      ignoredFiles: [] // default is to not ignore any files (js files also by default)
+    };
+
+    options = grunt.util._.extend(options, this.options());
 
     if (options.exec) {
       command.push('--exec');


### PR DESCRIPTION
Having ignoredFiles default to an empty array guarantees scrubbing the .nodemonignore file with fresh data every time the task is run. Currently if the user doesn't specify ignoredFiles or comments it out, thinking this will clear it, the .nodemonignore file is left untouched when the task is run.

Change for #4
