### PR TITLE
Missing bracket in README.md example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ concurrent: {
     options: {
       logConcurrentOutput: true
     }
+  }
 }
 ```
 ### Options


### PR DESCRIPTION
Thanks for making this awesome plugin.
