### PR TITLE
Add optional spawnOpts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ nodemon: {
       watchedExtensions: ['js', 'coffee'],
       watchedFolders: ['test', 'tasks'],
       debug: true,
-      delayTime: 1
+      delayTime: 1,
+      cwd: __dirname
     }
   },
   exec: {
@@ -97,6 +98,11 @@ Optionally launch the node.js debug server.
 Type: `Number`
 
 Delay the restart of nodemon by a number of seconds when compiling a large amount of files so that the app doesn't needlessly restart after each file.
+
+### cwd
+Type: `String`
+
+Optional configuration to change the current working directory.
 
 ### exec
 Type: `string`

--- a/tasks/nodemon.js
+++ b/tasks/nodemon.js
@@ -63,12 +63,18 @@ module.exports = function (grunt) {
       });
     }
 
+    var spawnOpts = {
+      stdio: 'inherit'
+    };
+
+    if (options.cwd) {
+      spawnOpts.cwd = options.cwd;
+    }
+
     grunt.util.spawn({
       cmd: 'node',
       args: command,
-      opts: {
-        stdio: 'inherit'
-      }
+      opts: spawnOpts
     },
     function (error, result) {
       if (error) {


### PR DESCRIPTION
Add optional spawnOpts object so the opts in child_process.spawn([arg], [opts]) can be configured in the gruntFile. This provides the gruntFile with more control over how the child_process is spawned. An example might be changing the current working directory (cwd):

``` js
nodemon: {
  server: {
    options: {
      file: 'server.js',
      args: ['NODE_ENV=' + environment.NODE_ENV],
      ignoredFiles: ['README.md','node_modules/**'],
      watchedExtensions: ['js'],
      watchedFolders: ['server'],
      debug: true,
      delayTime: 1,
      spawnOpts: {
        cwd: __dirname
       }
     }
   }
}
```

Read more about child_process.spawn([arg], [opts]) [here](http://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).

Documentation has been updated.
