### PR TITLE
Added support for --debug-brk

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ Type: `Boolean`
 
 Optionally launch the node.js debug server.
 
+### debugBreak
+Type: `Boolean`
+
+Optionally launch the node.js debug server, automatically setting a breakpoint on the first line (using `--debug-brk`).
+
 ### delayTime
 Type: `Number`
 

--- a/tasks/nodemon.js
+++ b/tasks/nodemon.js
@@ -55,6 +55,8 @@ module.exports = function (grunt) {
 
     if (options.debug) command.push('--debug');
 
+    if (options.debugBreak) command.push('--debug-brk');
+
     if (options.file) command.push(options.file);
 
     if (options.args) {


### PR DESCRIPTION
Added a debugBreak option to enable `--debug-brk`.

The reason you can't put `--debug-brk` using the `args` option is that `node app.js --debug-brk` doesn't work, whereas `node --debug-brk app.js` does work.
