### PR TITLE
Fixed the documentation for `watch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ String with comma separated file extensions to watch. By default, nodemon watche
 #### watch
 Type: `Array` of `Strings` Default: `['.']`
 
-List of folders to watch for changes if you don't want to watch the root folder and its subdirectories.
+List of additional folders to watch for changes.
 
 #### delay
 Type: `Number` Default: `1000`


### PR DESCRIPTION
The current documentation for `watch` parameter is incorrect. `nodemon` does not allow us to remove current folder from watched folders list. We can only add new folders to this list.
