### PR TITLE
Updated dependencies to use latest nodemon.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
-    "grunt-contrib-jshint": "^0.11.2",
+    "grunt-contrib-jshint": "^0.11.3",
     "grunt-mdlint": "0.0.1",
     "grunt-release": "^0.13.0",
     "grunt-simple-mocha": "^0.4.0",
-    "matchdep": "^0.3.0",
-    "should": "^7.0.4"
+    "matchdep": "^1.0.0",
+    "should": "^7.1.0"
   },
   "dependencies": {
-    "nodemon": "^1.4.1"
+    "nodemon": "^1.7.1"
   }
 }


### PR DESCRIPTION
The older nodemon version pulls in a very old touch dependency. All the tests still pass. the mdlint test doesn't seem to function properly, but the mocha/jshint tests pass.