### PR TITLE
upgrade nodemon to latest 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-nodemon",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Grunt task to run a nodemon monitor of your node.js server",
   "main": "test/fixtures/server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "should": "^7.1.0"
   },
   "dependencies": {
-    "nodemon": "^1.7.1"
+    "nodemon": "^1.18.7"
   }
 }


### PR DESCRIPTION
Fixes flatmap stream package which was removed from the npm registry. Any project that uses grunt-nodemon right now will 404 on install until this fix is in place. 